### PR TITLE
push通知機能を実装 (close #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,37 @@ python main.py run  # 新着を取得してDBに記録
 
 フィードの追加・削除は Web UI から行います。
 
+## Push通知
+
+ヘッダーの「通知」ボタンから購読できます。通知は `main.py run` 実行のたびに送信されます。
+
+VAPID鍵の生成：
+
+```bash
+python -c "from py_vapid import Vapid; v = Vapid(); v.generate_keys(); print('PRIVATE:', v.private_pem().decode()); print('PUBLIC:', v.public_key.public_bytes(__import__('cryptography.hazmat.primitives.serialization', fromlist=['Encoding','PublicFormat']).Encoding.X962, __import__('cryptography.hazmat.primitives.serialization', fromlist=['Encoding','PublicFormat']).PublicFormat.UncompressedPoint).hex())"
+# または py_vapid CLI: vapid --gen
+```
+
+環境変数に設定：
+
+```bash
+VAPID_PRIVATE_KEY=<秘密鍵>
+VAPID_PUBLIC_KEY=<公開鍵(URL-safe Base64)>
+VAPID_EMAIL=<your@email.com>
+```
+
+`docker-compose.override.yml` に追記する場合：
+
+```yaml
+services:
+  app:
+    environment:
+      - STARTS_TOKEN=<token>
+      - VAPID_PRIVATE_KEY=<秘密鍵>
+      - VAPID_PUBLIC_KEY=<公開鍵>
+      - VAPID_EMAIL=<your@email.com>
+```
+
 ## サーバーへのデプロイ (systemd)
 
 ```bash

--- a/api.py
+++ b/api.py
@@ -16,12 +16,17 @@ app = FastAPI()
 @app.middleware("http")
 async def auth_middleware(request: Request, call_next):
   expected = os.environ.get("STARTS_TOKEN", "")
-  if expected and request.query_params.get("token") != expected:
+  if expected and request.url.path not in ("/sw.js",) and request.query_params.get("token") != expected:
     return Response("Forbidden", status_code=403)
   return await call_next(request)
 
 class SourceRequest(BaseModel):
   url: str
+
+class PushSubscriptionRequest(BaseModel):
+  endpoint: str
+  p256dh: str
+  auth: str
 
 
 @app.get("/api/entries")
@@ -75,6 +80,33 @@ def delete_source(body: SourceRequest):
   if not db.delete_source(body.url):
     raise HTTPException(status_code=404, detail="見つかりません")
   return {"deleted": body.url}
+
+
+@app.get("/sw.js")
+def service_worker():
+  return FileResponse("static/sw.js", media_type="text/javascript")
+
+
+@app.get("/api/vapid-public-key")
+def get_vapid_public_key():
+  key = os.environ.get("VAPID_PUBLIC_KEY", "")
+  if not key:
+    raise HTTPException(status_code=503, detail="VAPID keys not configured")
+  return {"publicKey": key}
+
+
+@app.post("/api/push/subscribe", status_code=201)
+def subscribe_push(body: PushSubscriptionRequest):
+  db = StartsDB()
+  db.add_push_subscription(body.endpoint, body.p256dh, body.auth)
+  return {"subscribed": True}
+
+
+@app.delete("/api/push/subscribe")
+def unsubscribe_push(body: PushSubscriptionRequest):
+  db = StartsDB()
+  db.delete_push_subscription(body.endpoint)
+  return {"unsubscribed": True}
 
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/db/db.py
+++ b/db/db.py
@@ -32,6 +32,15 @@ class StartsDB:
           created_at TIMESTAMP DEFAULT (datetime('now', '+9 hours'))
         )
       """)
+      self.conn.execute("""
+        CREATE TABLE IF NOT EXISTS push_subscriptions
+        (
+          endpoint   TEXT PRIMARY KEY,
+          p256dh     TEXT NOT NULL,
+          auth       TEXT NOT NULL,
+          created_at TIMESTAMP DEFAULT (datetime('now', '+9 hours'))
+        )
+      """)
       self.conn.commit()
 
   def register_feed(self, title, link, domain, source_name):
@@ -67,3 +76,18 @@ class StartsDB:
     cur = self.conn.execute("DELETE FROM sources WHERE url = ?", (url,))
     self.conn.commit()
     return cur.rowcount > 0
+
+  def add_push_subscription(self, endpoint, p256dh, auth):
+    self.conn.execute(
+      "INSERT OR REPLACE INTO push_subscriptions (endpoint, p256dh, auth) VALUES (?, ?, ?)",
+      (endpoint, p256dh, auth)
+    )
+    self.conn.commit()
+
+  def delete_push_subscription(self, endpoint):
+    self.conn.execute("DELETE FROM push_subscriptions WHERE endpoint = ?", (endpoint,))
+    self.conn.commit()
+
+  def get_push_subscriptions(self):
+    res = self.conn.execute("SELECT endpoint, p256dh, auth FROM push_subscriptions").fetchall()
+    return [{"endpoint": r[0], "p256dh": r[1], "auth": r[2]} for r in res]

--- a/main.py
+++ b/main.py
@@ -3,7 +3,46 @@
 import feedparser
 import hashlib
 import argparse
+import json
+import os
 from db.db import StartsDB
+
+
+def send_push_notifications(db, new_count):
+  vapid_private_key = os.environ.get("VAPID_PRIVATE_KEY", "")
+  vapid_email = os.environ.get("VAPID_EMAIL", "")
+  if not vapid_private_key or not vapid_email:
+    return
+
+  try:
+    from pywebpush import webpush, WebPushException
+  except ImportError:
+    return
+
+  subscriptions = db.get_push_subscriptions()
+  if not subscriptions:
+    return
+
+  body = f"新着 {new_count} 件" if new_count > 0 else "新着エントリはありませんでした"
+  payload = json.dumps({"title": "starts", "body": body})
+
+  for sub in subscriptions:
+    try:
+      webpush(
+        subscription_info={
+          "endpoint": sub["endpoint"],
+          "keys": {"p256dh": sub["p256dh"], "auth": sub["auth"]},
+        },
+        data=payload,
+        vapid_private_key=vapid_private_key,
+        vapid_claims={"sub": f"mailto:{vapid_email}"},
+      )
+    except WebPushException as e:
+      status = e.response.status_code if e.response is not None else None
+      if status in (404, 410) or "410" in str(e) or "404" in str(e):
+        db.delete_push_subscription(sub["endpoint"])
+      else:
+        print(f"push送信失敗: {e}")
 
 
 def cmd_run(db, args):
@@ -26,6 +65,7 @@ def cmd_run(db, args):
       new_entries.append({"title": entry.title, "link": entry.link, "domain": source["domain"]})
 
   print(f"{len(new_entries)} 件の新着エントリを取得しました")
+  send_push_notifications(db, len(new_entries))
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.32.3
 fastapi==0.115.12
 uvicorn==0.34.0
 beautifulsoup4==4.13.3
+pywebpush==2.0.0

--- a/static/index.html
+++ b/static/index.html
@@ -128,6 +128,10 @@
     .btn-delete:hover { background: #fdd; }
     .btn-read { background: none; border: 1px solid #ccc; color: #888; font-size: .75rem; padding: .2rem .6rem; border-radius: 4px; }
     .btn-read:hover { background: #f0f0f0; }
+    .btn-notify { background: #f0f0f0; color: #444; }
+    .btn-notify:hover { background: #e0e0e0; }
+    .btn-notify.active { background: #5865f2; color: #fff; }
+    .btn-notify.active:hover { background: #4752c4; }
 
     .source-item {
       display: flex;
@@ -167,6 +171,7 @@
       <div class="tab active" onclick="switchTab('entries')">新着</div>
       <div class="tab" onclick="switchTab('sources')">フィード管理</div>
     </nav>
+    <button id="notifyBtn" class="btn-notify" onclick="toggleNotification()" style="margin-left:auto">通知OFF</button>
   </header>
 
   <main>
@@ -302,8 +307,66 @@
       document.getElementById(`entry-${id}`).remove();
     }
 
+    // --- push通知 ---
+    let swRegistration = null;
+
+    async function initNotification() {
+      if (!("serviceWorker" in navigator) || !("PushManager" in window)) return;
+      swRegistration = await navigator.serviceWorker.register("sw.js");
+      updateNotifyBtn();
+    }
+
+    async function updateNotifyBtn() {
+      if (!swRegistration) return;
+      const sub = await swRegistration.pushManager.getSubscription();
+      const btn = document.getElementById("notifyBtn");
+      btn.classList.toggle("active", !!sub);
+      btn.textContent = sub ? "通知ON" : "通知OFF";
+    }
+
+    async function toggleNotification() {
+      if (!swRegistration) return;
+      const existing = await swRegistration.pushManager.getSubscription();
+      if (existing) {
+        await fetch(api("/api/push/subscribe"), {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ endpoint: existing.endpoint, p256dh: btoa(String.fromCharCode(...new Uint8Array(existing.getKey("p256dh")))), auth: btoa(String.fromCharCode(...new Uint8Array(existing.getKey("auth")))) }),
+        });
+        await existing.unsubscribe();
+      } else {
+        const res = await fetch(api("/api/vapid-public-key"));
+        if (!res.ok) { alert("VAPID keys が設定されていません"); return; }
+        const { publicKey } = await res.json();
+        const perm = await Notification.requestPermission();
+        if (perm !== "granted") return;
+        const sub = await swRegistration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(publicKey),
+        });
+        await fetch(api("/api/push/subscribe"), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            endpoint: sub.endpoint,
+            p256dh: btoa(String.fromCharCode(...new Uint8Array(sub.getKey("p256dh")))),
+            auth: btoa(String.fromCharCode(...new Uint8Array(sub.getKey("auth")))),
+          }),
+        });
+      }
+      updateNotifyBtn();
+    }
+
+    function urlBase64ToUint8Array(base64String) {
+      const padding = "=".repeat((4 - base64String.length % 4) % 4);
+      const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+      const rawData = atob(base64);
+      return Uint8Array.from([...rawData].map(c => c.charCodeAt(0)));
+    }
+
     loadEntries();
     loadSources();
+    initNotification();
   </script>
 </body>
 </html>

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,0 +1,15 @@
+self.addEventListener("push", (event) => {
+  let data = { title: "starts", body: "フィードを取得しました" };
+  try {
+    data = JSON.parse(event.data.text());
+  } catch (e) {}
+
+  event.waitUntil(
+    self.registration.showNotification(data.title, { body: data.body })
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  event.waitUntil(self.clients.openWindow("/"));
+});


### PR DESCRIPTION
- pywebpush によるWeb Push送信 (main.py run 実行時に全購読者へ通知)
- push_subscriptions テーブル追加・購読管理API追加
- Service Worker (sw.js) 追加・ヘッダーに通知ON/OFFボタン追加
- /sw.js を認証対象外に設定・text/javascript で配信