### PR TITLE
feat: タイトルクリックで表示中タブを最新化

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -182,7 +182,7 @@
 </head>
 <body>
   <header>
-    <h1>s4s</h1>
+    <h1 onclick="refresh()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();refresh();}" role="button" tabindex="0" aria-label="一覧を最新化" style="cursor:pointer" title="クリックで最新化">s4s</h1>
     <nav class="tabs">
       <div class="tab active" onclick="switchTab('entries')">新着</div>
       <div class="tab" onclick="switchTab('saved')">キュー</div>
@@ -236,6 +236,11 @@
       if (name === "entries") loadEntries();
       if (name === "saved") loadSaved();
       if (name === "sources") loadSources();
+    }
+
+    function refresh() {
+      const active = document.querySelector(".page.active");
+      if (active) switchTab(active.id.replace("page-", ""));
     }
 
     const initialTab = location.hash.replace("#", "") || "entries";


### PR DESCRIPTION
## 概要
ヘッダーのタイトル「s4s」をクリック（およびキーボードの Enter / Space）すると、現在表示中タブの一覧を API から再取得して最新化する。

サーバ側にフィード取得（`main.py run` 相当）を起動する API は無いため、ここでの「最新化」は **表示中タブのリストを API から再フェッチして再描画** することを指す（フルページリロードはしない）。

## 変更点（`static/index.html` のみ）
- `<h1>` に `onclick="refresh()"` と `cursor:pointer` / `title` を付与
- アクセシビリティ対応: `role="button"` `tabindex="0"` `aria-label="一覧を最新化"`、Enter/Space で発火する `onkeydown`
- `refresh()` を追加。active な `.page` の id から name を導出し `switchTab` に委譲（取得ロジックを重複させない）

## レビュー
reviewer サブエージェントで2往復レビューし収束済み（DRY化・アクセシビリティ指摘を反映）。

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)