### PR TITLE
デグレ防止用の自動テスト基盤（pytest）を導入

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ CREATE TABLE push_subscriptions (
 - **「削除」はソフト削除**: `DELETE /api/entries/{id}` は実際にはレコードを消さず `read=1` を立てるだけ（＝既読化）。同様に `DELETE /api/saved/{id}` は `saved=0, read=1`。物理削除されるのはフィード購読解除時のみ。
 - **フィード購読解除はカスケード**: `delete_source()` は同一 `domain` の `feeds` レコードを全削除する。URL ではなく domain でひも付くため、同一ドメインの別フィードを登録していると巻き添えで消える。
 - **認証**: `STARTS_TOKEN` 設定時、クエリパラメータ `?token=` が一致しないと 403。例外パスは `/sw.js` `/manifest.json` `/icon.png`（PWA がトークンなしで取得する必要があるため）。未設定時は全リクエスト拒否。
-- **テスト**: 専用フレームワークなし。`util/url.py` は `python util/url.py` で実行するとインラインの assert が走る。
+- **テスト**: `pytest` を導入済み。`pip install -r requirements-dev.txt` 後に `pytest` で実行する（テストは `tests/` 配下）。`StartsDB(db_path=...)` で一時ファイル DB を渡してテスト間を隔離する（引数なしなら従来どおり `data/stars.db`）。API テストは `STARTS_TOKEN` 未設定で認証 middleware を素通りさせ、`api.StartsDB` を一時 DB ファクトリに、`fetch_page_title` をモックに差し替える。実ネットワークは叩かない（`requests.get` を monkeypatch）。`util/url.py` の `python util/url.py` によるインライン assert も従来どおり残してある。
 - **コード規約**: Python はインデント2スペース（PEP8 の4スペースではない）。既存ファイルに合わせること。
 
 ## 開発ワークフロー（developer / reviewer）

--- a/db/db.py
+++ b/db/db.py
@@ -3,10 +3,11 @@ import os
 import hashlib
 
 class StartsDB:
-  def __init__(self):
-    base_dir = os.path.dirname(os.path.abspath(__file__))
-    DB_PATH = os.path.join(base_dir, "..", "data", "stars.db")
-    self.db_path = DB_PATH
+  def __init__(self, db_path=None):
+    if db_path is None:
+      base_dir = os.path.dirname(os.path.abspath(__file__))
+      db_path = os.path.join(base_dir, "..", "data", "stars.db")
+    self.db_path = db_path
     self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
     self._init_db()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+httpx==0.28.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+import pytest
+
+# プロジェクトルートを import パスに追加（db / util / api を解決するため）
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from db.db import StartsDB
+
+
+@pytest.fixture
+def db(tmp_path):
+  """テストごとに隔離した一時ファイル DB を返す。"""
+  db_path = str(tmp_path / "test.db")
+  database = StartsDB(db_path=db_path)
+  yield database
+  database.conn.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,40 @@
+"""api.py の HTTP エンドポイントのテスト（TestClient 使用、実ネットワーク不使用）。
+
+STARTS_TOKEN を未設定にすることで認証 middleware は素通りする（expected が空文字のため）。
+api.py は各エンドポイント内で StartsDB() を引数なしで生成するため、
+テストでは api.StartsDB を一時ファイル DB を使うファクトリに差し替えて本番 DB を汚さない。
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api
+from db.db import StartsDB
+
+
+@pytest.fixture
+def app_client(tmp_path, monkeypatch):
+  monkeypatch.delenv("STARTS_TOKEN", raising=False)
+  db_path = str(tmp_path / "api.db")
+  monkeypatch.setattr(api, "StartsDB", lambda: StartsDB(db_path=db_path))
+  return TestClient(api.app)
+
+
+def test_post_saved_invalid_url_returns_400(app_client, monkeypatch):
+  # ドメインが取れない無効 URL → 400。fetch_page_title は呼ばれない想定だが念のためモック。
+  monkeypatch.setattr(api, "fetch_page_title", lambda url: "should-not-be-used")
+  resp = app_client.post("/api/saved", json={"url": "not a url"})
+  assert resp.status_code == 400
+
+
+def test_post_saved_valid_url_succeeds(app_client, monkeypatch):
+  monkeypatch.setattr(api, "fetch_page_title", lambda url: "モックタイトル")
+  resp = app_client.post("/api/saved", json={"url": "https://example.com/article"})
+  assert resp.status_code == 201
+  body = resp.json()
+  assert body["link"] == "https://example.com/article"
+  assert body["title"] == "モックタイトル"
+  assert body["domain"] == "example.com"
+  # 後で読む一覧に追加されている
+  saved = app_client.get("/api/saved").json()
+  assert any(s["link"] == "https://example.com/article" for s in saved)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,140 @@
+"""StartsDB の DB 操作に関するテスト。"""
+
+import hashlib
+
+
+def _hash(link):
+  return hashlib.md5(link.encode()).hexdigest()
+
+
+# --- add_saved_link の UPSERT セマンティクス ---
+
+def test_add_saved_link_new(db):
+  """新規追加は saved=1 / read=0 で記録される。"""
+  db.add_saved_link("タイトル", "https://example.com/a", "example.com", "example.com")
+  saved = db.fetch_saved()
+  assert len(saved) == 1
+  assert saved[0]["title"] == "タイトル"
+  assert saved[0]["link"] == "https://example.com/a"
+  # fetch_saved は saved=1 のみ返すので、ここに出る時点で saved=1
+  # read=0 であることも確認（read=1 なら fetch_entries には出ないが saved には出る）
+  h = _hash("https://example.com/a")
+  row = db.conn.execute("SELECT read, saved FROM feeds WHERE url_2_hash = ?", (h,)).fetchone()
+  assert row == (0, 1)
+
+
+def test_add_saved_link_conflict_resaves(db):
+  """既存エントリ（既読化済み）に同一URLを add_saved_link すると saved=1 / read=0 に戻る。"""
+  link = "https://example.com/a"
+  # 通常エントリとして登録し、既読化する
+  db.register_feed("元タイトル", link, "example.com", "元ソース")
+  db.delete_entry(_hash(link))  # read=1
+  # 同一URLを後で読むに直接追加
+  db.add_saved_link("新タイトル", link, "example.com", "example.com")
+  row = db.conn.execute(
+    "SELECT read, saved, title FROM feeds WHERE url_2_hash = ?", (_hash(link),)
+  ).fetchone()
+  assert row[0] == 0  # read=0 に戻る
+  assert row[1] == 1  # saved=1
+  assert row[2] == "元タイトル"  # タイトルは上書きされない
+
+
+def test_add_saved_link_conflict_keeps_existing_title(db):
+  """URL衝突時、既存タイトルは上書きされない。"""
+  link = "https://example.com/a"
+  db.register_feed("元タイトル", link, "example.com", "元ソース")
+  db.add_saved_link("新タイトル", link, "example.com", "example.com")
+  row = db.conn.execute(
+    "SELECT title FROM feeds WHERE url_2_hash = ?", (_hash(link),)
+  ).fetchone()
+  assert row[0] == "元タイトル"
+
+
+# --- ソフト削除セマンティクス ---
+
+def test_delete_entry_soft(db):
+  """delete_entry は read=1 を立てるソフト削除。"""
+  link = "https://example.com/a"
+  db.register_feed("t", link, "example.com", "s")
+  assert db.delete_entry(_hash(link)) is True
+  row = db.conn.execute(
+    "SELECT read FROM feeds WHERE url_2_hash = ?", (_hash(link),)
+  ).fetchone()
+  assert row[0] == 1
+
+
+def test_delete_entry_missing_returns_false(db):
+  assert db.delete_entry("notexist") is False
+
+
+def test_save_entry(db):
+  link = "https://example.com/a"
+  db.register_feed("t", link, "example.com", "s")
+  assert db.save_entry(_hash(link)) is True
+  row = db.conn.execute(
+    "SELECT saved FROM feeds WHERE url_2_hash = ?", (_hash(link),)
+  ).fetchone()
+  assert row[0] == 1
+
+
+def test_save_entry_missing_returns_false(db):
+  assert db.save_entry("notexist") is False
+
+
+def test_delete_saved_soft(db):
+  """delete_saved は saved=0 / read=1 にする。"""
+  link = "https://example.com/a"
+  db.add_saved_link("t", link, "example.com", "example.com")
+  assert db.delete_saved(_hash(link)) is True
+  row = db.conn.execute(
+    "SELECT read, saved FROM feeds WHERE url_2_hash = ?", (_hash(link),)
+  ).fetchone()
+  assert row == (1, 0)
+
+
+def test_delete_saved_missing_returns_false(db):
+  assert db.delete_saved("notexist") is False
+
+
+# --- fetch_entries / fetch_saved のフィルタ ---
+
+def test_fetch_entries_filters_read_and_saved(db):
+  """fetch_entries は read=0 AND saved=0 のみ返す。"""
+  db.register_feed("unread", "https://example.com/1", "example.com", "s")
+  db.register_feed("toread", "https://example.com/2", "example.com", "s")
+  db.register_feed("done", "https://example.com/3", "example.com", "s")
+  db.save_entry(_hash("https://example.com/2"))   # saved=1 → 除外
+  db.delete_entry(_hash("https://example.com/3"))  # read=1 → 除外
+  entries = db.fetch_entries()
+  titles = {e["title"] for e in entries}
+  assert titles == {"unread"}
+
+
+def test_fetch_saved_filters_saved(db):
+  """fetch_saved は saved=1 のみ返す。"""
+  db.register_feed("unread", "https://example.com/1", "example.com", "s")
+  db.register_feed("toread", "https://example.com/2", "example.com", "s")
+  db.save_entry(_hash("https://example.com/2"))
+  saved = db.fetch_saved()
+  titles = {e["title"] for e in saved}
+  assert titles == {"toread"}
+
+
+# --- delete_source の domain カスケード削除 ---
+
+def test_delete_source_cascades_by_domain(db):
+  """delete_source は同一 domain の feeds を全削除し、別 domain は残す。"""
+  db.add_source("https://example.com/feed", "example.com", "Example")
+  db.register_feed("a", "https://example.com/a", "example.com", "Example")
+  db.register_feed("b", "https://example.com/b", "example.com", "Example")
+  db.register_feed("other", "https://other.com/x", "other.com", "Other")
+  assert db.delete_source("https://example.com/feed") is True
+  remaining = db.conn.execute("SELECT domain FROM feeds").fetchall()
+  domains = {r[0] for r in remaining}
+  assert domains == {"other.com"}
+  # source も消える
+  assert db.get_sources() == []
+
+
+def test_delete_source_missing_returns_false(db):
+  assert db.delete_source("https://notexist.com/feed") is False

--- a/tests/test_util_feed.py
+++ b/tests/test_util_feed.py
@@ -1,0 +1,46 @@
+"""util/feed.py::fetch_page_title のテスト（requests を monkeypatch、実ネットワーク不使用）。"""
+
+import pytest
+
+import util.feed as feed
+from util.feed import fetch_page_title
+
+
+class _FakeResp:
+  def __init__(self, text):
+    self.text = text
+
+  def raise_for_status(self):
+    pass
+
+
+def test_fetch_page_title_success(monkeypatch):
+  """<title> が取得できればその文字列を返す。"""
+  def fake_get(url, **kwargs):
+    return _FakeResp("<html><head><title>  ページ名  </title></head></html>")
+  monkeypatch.setattr(feed.requests, "get", fake_get)
+  assert fetch_page_title("https://example.com/a") == "ページ名"
+
+
+def test_fetch_page_title_empty_falls_back_to_url(monkeypatch):
+  """<title> が空文字ならフォールバックで URL を返す。"""
+  def fake_get(url, **kwargs):
+    return _FakeResp("<html><head><title>   </title></head></html>")
+  monkeypatch.setattr(feed.requests, "get", fake_get)
+  assert fetch_page_title("https://example.com/a") == "https://example.com/a"
+
+
+def test_fetch_page_title_no_title_falls_back_to_url(monkeypatch):
+  """<title> 要素自体が無ければフォールバックで URL を返す。"""
+  def fake_get(url, **kwargs):
+    return _FakeResp("<html><head></head><body>x</body></html>")
+  monkeypatch.setattr(feed.requests, "get", fake_get)
+  assert fetch_page_title("https://example.com/a") == "https://example.com/a"
+
+
+def test_fetch_page_title_exception_falls_back_to_url(monkeypatch):
+  """取得時に例外が出てもフォールバックで URL を返す（例外は送出しない）。"""
+  def fake_get(url, **kwargs):
+    raise RuntimeError("network down")
+  monkeypatch.setattr(feed.requests, "get", fake_get)
+  assert fetch_page_title("https://example.com/a") == "https://example.com/a"

--- a/tests/test_util_url.py
+++ b/tests/test_util_url.py
@@ -1,0 +1,30 @@
+"""util/url.py::get_domain のテスト（inline assert を pytest に移植）。"""
+
+from util.url import get_domain
+
+
+def test_get_domain_https_with_path():
+  assert get_domain("https://google.com/path") == "google.com"
+
+
+def test_get_domain_with_port():
+  assert get_domain("http://localhost:8080") == "localhost:8080"
+
+
+def test_get_domain_cojp():
+  assert get_domain("http://yahoo.co.jp") == "yahoo.co.jp"
+
+
+def test_get_domain_invalid_returns_empty():
+  # スキームが無いと netloc が空になる（api.py の 400 バリデーションが依存する挙動）
+  assert get_domain("not a url") == ""
+
+
+def test_get_domain_path_only_returns_empty():
+  # パスのみ（スキーム無し）も netloc は空
+  assert get_domain("foo/bar") == ""
+
+
+def test_get_domain_scheme_relative():
+  # スキームレス authority（//host/path）は netloc が取れる
+  assert get_domain("//example.com/x") == "example.com"


### PR DESCRIPTION
## 概要
実装のたびにデグレを検知できるよう、`pytest` ベースのテスト基盤を導入する。テスト実行は手動（`pytest`）想定で、自動 hook は入れない。Closes #30

## 変更内容
- **前提リファクタ**: `StartsDB.__init__(self, db_path=None)` を導入。None のとき従来どおり `data/stars.db` を使う後方互換。テストでは一時ファイル DB を注入して隔離する。既存の `api.py` / `main.py` の呼び出し（引数なし）はそのまま動作。
- **依存分離**: `requirements-dev.txt`（pytest, httpx）を追加。`pytest.ini` で `testpaths=tests`。
- **テスト**（`tests/` 配下、全25件）:
  - `test_db.py`: `add_saved_link` の UPSERT（新規 / URL衝突で saved=1,read=0 へ更新 / 既存タイトル非上書き）、ソフト削除（`delete_entry`→read=1 / `delete_saved`→saved=0,read=1 / `save_entry`→saved=1 と各戻り値）、`fetch_entries`（read=0 AND saved=0）/ `fetch_saved`（saved=1）のフィルタ、`delete_source` の domain カスケード削除。
  - `test_util_url.py`: `get_domain`（inline assert を移植 + 無効URL境界）。
  - `test_util_feed.py`: `fetch_page_title` を `requests` の monkeypatch で3分岐検証（成功 / 空タイトル→URLフォールバック / 例外→URLフォールバック）。実ネットワーク不使用。
  - `test_api.py`: `POST /api/saved`（無効URL→400 / 有効URL→201）。`api.StartsDB` を一時 DB ファクトリに、`fetch_page_title` をモックに差し替え、`STARTS_TOKEN` 未設定で認証 middleware を素通り。
- **ドキュメント**: CLAUDE.md「テスト」項を pytest 導入後の実態に更新。

## 実行方法
\`\`\`bash
pip install -r requirements-dev.txt
pytest
\`\`\`

## テスト結果
`25 passed`（実ネットワークアクセスなし、本番 DB を汚さない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)