### PR TITLE
スマホの横スワイプでタブを切り替える

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -232,9 +232,12 @@
     let swRegistration = null;
     let vapidPublicKey = null;
 
+    // タブの並び順（横位置）。スワイプ切替・active 判定・hash 検証で共用する
+    const TABS = ["entries", "saved", "sources"];
+
     function switchTab(name) {
       document.querySelectorAll(".tab").forEach((t, i) => {
-        t.classList.toggle("active", ["entries", "saved", "sources"][i] === name);
+        t.classList.toggle("active", TABS[i] === name);
       });
       document.querySelectorAll(".page").forEach(p => {
         p.classList.toggle("active", p.id === `page-${name}`);
@@ -251,8 +254,41 @@
     }
 
     const initialTab = location.hash.replace("#", "") || "entries";
-    switchTab(["entries", "saved", "sources"].includes(initialTab) ? initialTab : "entries");
+    switchTab(TABS.includes(initialTab) ? initialTab : "entries");
     initNotification();
+
+    // スマホでの横スワイプによるタブ切替（縦スクロールは阻害しない）
+    (function setupSwipe() {
+      const SWIPE_THRESHOLD = 50; // 横移動量がこれを超えたら切替
+      let startX = 0, startY = 0, tracking = false;
+      const main = document.querySelector("main");
+
+      main.addEventListener("touchstart", (e) => {
+        if (e.touches.length !== 1) { tracking = false; return; }
+        startX = e.touches[0].clientX;
+        startY = e.touches[0].clientY;
+        tracking = true;
+      }, { passive: true });
+
+      main.addEventListener("touchend", (e) => {
+        if (!tracking) return;
+        tracking = false;
+        const t = e.changedTouches[0];
+        const dx = t.clientX - startX;
+        const dy = t.clientY - startY;
+        // 横移動が縦移動より大きく、かつ閾値超のときのみ発火
+        if (Math.abs(dx) <= Math.abs(dy) || Math.abs(dx) < SWIPE_THRESHOLD) return;
+        const active = document.querySelector(".page.active");
+        if (!active) return;
+        const current = TABS.indexOf(active.id.replace("page-", ""));
+        if (current < 0) return;
+        const next = dx < 0 ? current + 1 : current - 1; // 左スワイプで右隣、右スワイプで左隣
+        if (next < 0 || next >= TABS.length) return; // 端ではループしない
+        switchTab(TABS[next]);
+      }, { passive: true });
+
+      main.addEventListener("touchcancel", () => { tracking = false; }, { passive: true });
+    })();
 
     async function loadEntries() {
       const res = await fetch(api("/api/entries"));


### PR DESCRIPTION
## 概要
スマホ利用時、ヘッダーのタブ（新着 / キュー / フィード）を横フリックで切り替えられるようにしました（案A: スナップ切替）。

Closes #34

## 変更内容
- `main` 領域の `touchstart`/`touchend` で横スワイプを検知。
  - 左スワイプ → 右隣のタブ（entries→saved→sources）
  - 右スワイプ → 左隣のタブ（sources→saved→entries）
  - 端ではループしない。
- 縦スクロールとの競合回避: 横移動量 > 縦移動量 かつ横移動量が閾値(50px)超のときのみ発火。`preventDefault` は使わない。
- 既存の `switchTab(name)` をそのまま呼び、遅延ロード・`location.hash` 同期・タブ active 表示を維持。
- タブ順配列 `["entries","saved","sources"]`（従来3箇所に直書き）を定数 `TABS` に一元化。
- マルチタッチ（ピンチ等）は除外。`touchcancel` で内部状態をリセット。

## 影響範囲
- 変更は `static/index.html` 内で完結。サーバ・DB は未変更。
- PC のマウス操作・タブクリック・hash 直リンクは従来どおり動作。

## レビュー
reviewer により承認（指摘なし）。任意指摘の `touchcancel` 未処理対応のみ追加で取り込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)