### PR TITLE
feat: キュータブにタイトル絞り込み検索を追加

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -139,6 +139,16 @@
 
     .add-form { display: flex; gap: .5rem; }
 
+    .search-box { margin-bottom: .75rem; }
+
+    .search-box input {
+      width: 100%;
+      padding: .5rem .75rem;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      font-size: 1rem;
+    }
+
     .add-form input {
       flex: 1;
       min-width: 0;
@@ -231,6 +241,9 @@
             </div>
             <div id="savedAddError" class="error"></div>
           </div>
+          <div class="search-box">
+            <input id="savedSearchInput" type="search" placeholder="タイトルで絞り込み" oninput="renderSaved()" />
+          </div>
           <div id="savedList" class="entry-list"></div>
         </div>
       </div>
@@ -260,6 +273,7 @@
     const api = (path) => `${BASE}${path}?token=${encodeURIComponent(TOKEN)}`;
     let swRegistration = null;
     let vapidPublicKey = null;
+    let savedEntries = [];
 
     // タブの並び順（横位置）。スワイプ切替・active 判定・hash 検証で共用する
     const TABS = ["entries", "saved", "sources"];
@@ -457,11 +471,25 @@
 
     async function loadSaved() {
       const res = await fetch(api("/api/saved"));
-      const entries = await res.json();
+      savedEntries = await res.json();
+      renderSaved();
+    }
+
+    function renderSaved() {
       const el = document.getElementById("savedList");
 
-      if (entries.length === 0) {
+      if (savedEntries.length === 0) {
         el.innerHTML = '<div class="empty">後で読む記事はありません</div>';
+        return;
+      }
+
+      const q = document.getElementById("savedSearchInput").value.trim().toLowerCase();
+      const entries = q
+        ? savedEntries.filter(e => (e.title ?? "").toLowerCase().includes(q))
+        : savedEntries;
+
+      if (entries.length === 0) {
+        el.innerHTML = '<div class="empty">該当する記事はありません</div>';
         return;
       }
 
@@ -512,7 +540,8 @@
 
     async function deleteSaved(id) {
       await fetch(api(`/api/saved/${id}`), { method: "DELETE" });
-      document.getElementById(`saved-${id}`).remove();
+      savedEntries = savedEntries.filter(e => String(e.id) !== String(id));
+      renderSaved();
     }
 
     // --- push通知 ---


### PR DESCRIPTION
## 概要

issue #38「キューの内容を記事検索出来るようにしたい」対応。

「後で読む」(キュー) タブに、登録済み記事を**タイトル**で絞り込むインクリメンタル検索ボックスを追加した。クライアントサイドのフィルタで実装しており、新規 API・DB スキーマ変更はなし。変更は `static/index.html` のみ。

## 変更内容

- `loadSaved()` で取得した記事配列をモジュールスコープ変数 `savedEntries` に保持。
- 描画ロジックを `renderSaved()` に分離。検索 input の値で**部分一致・大文字小文字無視**でタイトルをフィルタして再描画。
- `savedList` 上部に検索 input（`type="search"`, `oninput="renderSaved()"`）を追加。CSS は既存 `.add-form input` のトーンに合わせた `.search-box`。
- 空表示の出し分け: 保存 0 件は「後で読む記事はありません」、フィルタ後 0 件は「該当する記事はありません」。
- `deleteSaved()` を DOM 直接 remove から `savedEntries` 更新＋`renderSaved()` 再描画に変更。削除後も現在の検索語を維持。
- `addSaved()` は既存どおり `loadSaved()` を呼ぶ。検索 input はクリアしないため検索語を維持。

## 手動確認の観点（static/ は pytest 対象外）

- [ ] キュータブの検索ボックスにタイトルの一部を入力すると、該当記事のみに絞り込まれる
- [ ] 大文字・小文字を区別せず一致する（例: "ABC" でも "abc" でもヒット）
- [ ] 検索ボックスをクリアすると全件表示に戻る
- [ ] ヒット 0 件のとき「該当する記事はありません」が表示される
- [ ] 保存記事が 0 件のとき「後で読む記事はありません」が表示される
- [ ] 検索で絞り込んだ状態で記事を削除しても、検索語が維持されたまま再描画される
- [ ] 検索語が入った状態で記事を追加（追加→loadSaved）しても検索語が維持される

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)