### PR TITLE
登録済みフィードの表示名を後から変更する機能

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ CREATE TABLE push_subscriptions (
 - **ハッシュ生成は1箇所に集約**: エントリの一意キー（URLのMD5）生成は `StartsDB._hash` に集約済み。新たにハッシュ突き合わせ（`fetch_all()` との比較など）を書くときは必ず `StartsDB._hash` を使い、`hashlib.md5(...)` を直書きしないこと。方式変更時に重複検知がサイレントに壊れるのを防ぐため。
 - **「削除」はソフト削除**: `DELETE /api/entries/{id}` は実際にはレコードを消さず `read=1` を立てるだけ（＝既読化）。同様に `DELETE /api/saved/{id}` は `saved=0, read=1`。物理削除されるのはフィード購読解除時のみ。
 - **フィード購読解除はカスケード**: `delete_source()` は同一 `domain` の `feeds` レコードを全削除する。URL ではなく domain でひも付くため、同一ドメインの別フィードを登録していると巻き添えで消える。
+- **フィード名変更も domain 単位**: `rename_source()`（`PATCH /api/sources`）は `sources.name` を更新すると同時に、同一 `domain` の `feeds.source_name` も一括更新する（既存記事の表示名にも反映するため）。`delete_source` と同じく domain でひも付くため、同一ドメインに複数 source を登録していると別 source の記事の表示名まで巻き添えで書き換わる。
 - **認証**: `STARTS_TOKEN` 設定時、クエリパラメータ `?token=` が一致しないと 403。例外パスは `/sw.js` `/manifest.json` `/icon.png`（PWA がトークンなしで取得する必要があるため）。未設定時は全リクエスト拒否。
 - **テスト**: `pytest` を導入済み。`pip install -r requirements-dev.txt` 後に `pytest` で実行する（テストは `tests/` 配下）。`StartsDB(db_path=...)` で一時ファイル DB を渡してテスト間を隔離する（引数なしなら従来どおり `data/stars.db`）。API テストは `STARTS_TOKEN` 未設定で認証 middleware を素通りさせ、`api.StartsDB` を一時 DB ファクトリに、`fetch_page_title` をモックに差し替える。実ネットワークは叩かない（`requests.get` を monkeypatch）。`util/url.py` の `python util/url.py` によるインライン assert も従来どおり残してある。`static/` の HTML/JS（`index.html` `sw.js` 等）は pytest の対象外なので、変更時は PR 本文に手動確認の観点を列挙する。
 - **コード規約**: Python はインデント2スペース（PEP8 の4スペースではない）。既存ファイルに合わせること。

--- a/api.py
+++ b/api.py
@@ -22,6 +22,10 @@ async def auth_middleware(request: Request, call_next):
 class SourceRequest(BaseModel):
   url: str
 
+class SourceRenameRequest(BaseModel):
+  url: str
+  name: str
+
 class SavedRequest(BaseModel):
   url: str
 
@@ -74,6 +78,17 @@ def add_source(body: SourceRequest):
     existing_hashes.add(content_hash)
 
   return {"url": feed["url"], "domain": domain, "name": name}
+
+
+@app.patch("/api/sources")
+def rename_source(body: SourceRenameRequest):
+  db = StartsDB()
+  name = body.name.strip()
+  if not name:
+    raise HTTPException(status_code=400, detail="名前を入力してください")
+  if not db.rename_source(body.url, name):
+    raise HTTPException(status_code=404, detail="見つかりません")
+  return {"url": body.url, "name": name}
 
 
 @app.delete("/api/sources")

--- a/db/db.py
+++ b/db/db.py
@@ -105,6 +105,16 @@ class StartsDB:
     res = self.conn.execute("SELECT url, domain, name, created_at FROM sources ORDER BY created_at").fetchall()
     return [{"url": r[0], "domain": r[1], "name": r[2], "created_at": r[3]} for r in res]
 
+  def rename_source(self, url, name):
+    cur = self.conn.execute("UPDATE sources SET name = ? WHERE url = ?", (name, url))
+    if cur.rowcount > 0:
+      self.conn.execute(
+        "UPDATE feeds SET source_name = ? WHERE domain = (SELECT domain FROM sources WHERE url = ?)",
+        (name, url)
+      )
+    self.conn.commit()
+    return cur.rowcount > 0
+
   def delete_source(self, url):
     self.conn.execute("DELETE FROM feeds WHERE domain = (SELECT domain FROM sources WHERE url = ?)", (url,))
     cur = self.conn.execute("DELETE FROM sources WHERE url = ?", (url,))

--- a/static/index.html
+++ b/static/index.html
@@ -171,6 +171,8 @@
     .btn-add:hover { background: #4752c4; }
     .btn-delete { background: #f0f0f0; color: #c00; }
     .btn-delete:hover { background: #fdd; }
+    .btn-rename { background: #f0f0f0; color: #444; }
+    .btn-rename:hover { background: #e0e0e0; }
     .btn-read { background: none; border: 1px solid #ccc; color: #888; font-size: .75rem; padding: .2rem .6rem; border-radius: 4px; }
     .btn-read:hover { background: #f0f0f0; }
     .btn-save { background: none; border: 1px solid #5865f2; color: #5865f2; font-size: .75rem; padding: .2rem .6rem; border-radius: 4px; }
@@ -190,6 +192,8 @@
     }
 
     .source-item:last-child { border-bottom: none; }
+
+    .source-actions { display: flex; gap: .5rem; flex-shrink: 0; }
 
     .source-info { min-width: 0; }
     .source-domain { font-weight: 600; font-size: .9rem; }
@@ -389,9 +393,12 @@
       }).join("");
     }
 
+    let sourcesCache = [];
+
     async function loadSources() {
       const res = await fetch(api("/api/sources"));
       const sources = await res.json();
+      sourcesCache = sources;
       const el = document.getElementById("sourceList");
 
       if (sources.length === 0) {
@@ -405,9 +412,32 @@
             <div class="source-domain">${s.name ?? s.domain}</div>
             <div class="source-url">${s.url}</div>
           </div>
-          <button class="btn-delete" onclick="deleteSource('${s.url}')">削除</button>
+          <div class="source-actions">
+            <button class="btn-rename" onclick="renameSource('${s.url}')">名前変更</button>
+            <button class="btn-delete" onclick="deleteSource('${s.url}')">削除</button>
+          </div>
         </div>
       `).join("");
+    }
+
+    async function renameSource(url) {
+      const current = sourcesCache.find(s => s.url === url);
+      const cur = current ? (current.name ?? current.domain) : "";
+      const input = prompt("新しいフィード名", cur);
+      if (input === null) return;
+      const name = input.trim();
+      if (!name) return;
+      const res = await fetch(api("/api/sources"), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url, name })
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        alert(data.detail ?? "エラーが発生しました");
+        return;
+      }
+      await Promise.all([loadSources(), loadEntries()]);
     }
 
     async function addSource() {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,3 +38,51 @@ def test_post_saved_valid_url_succeeds(app_client, monkeypatch):
   # 後で読む一覧に追加されている
   saved = app_client.get("/api/saved").json()
   assert any(s["link"] == "https://example.com/article" for s in saved)
+
+
+# --- PATCH /api/sources（フィード名変更） ---
+
+def _seed_source(db_path):
+  """テスト用に source と feeds を1件ずつ登録する。"""
+  db = StartsDB(db_path=db_path)
+  db.add_source("https://example.com/feed", "example.com", "旧名")
+  db.register_feed("記事", "https://example.com/a", "example.com", "旧名")
+  db.conn.close()
+
+
+def test_patch_source_renames(app_client, tmp_path):
+  db_path = str(tmp_path / "api.db")
+  _seed_source(db_path)
+  resp = app_client.patch(
+    "/api/sources", json={"url": "https://example.com/feed", "name": "新名"}
+  )
+  assert resp.status_code == 200
+  assert resp.json()["name"] == "新名"
+
+  # sources 一覧に反映
+  sources = app_client.get("/api/sources").json()
+  assert any(s["url"] == "https://example.com/feed" and s["name"] == "新名" for s in sources)
+
+  # 既存記事の source_name も更新される
+  db = StartsDB(db_path=db_path)
+  name = db.conn.execute(
+    "SELECT source_name FROM feeds WHERE domain = ?", ("example.com",)
+  ).fetchone()[0]
+  db.conn.close()
+  assert name == "新名"
+
+
+def test_patch_source_strips_and_rejects_blank(app_client, tmp_path):
+  db_path = str(tmp_path / "api.db")
+  _seed_source(db_path)
+  resp = app_client.patch(
+    "/api/sources", json={"url": "https://example.com/feed", "name": "   "}
+  )
+  assert resp.status_code == 400
+
+
+def test_patch_source_missing_returns_404(app_client):
+  resp = app_client.patch(
+    "/api/sources", json={"url": "https://notexist.com/feed", "name": "新名"}
+  )
+  assert resp.status_code == 404

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -139,3 +139,58 @@ def test_delete_source_cascades_by_domain(db):
 
 def test_delete_source_missing_returns_false(db):
   assert db.delete_source("https://notexist.com/feed") is False
+
+
+# --- rename_source ---
+
+def test_rename_source_updates_name_and_feeds(db):
+  """rename_source は sources.name と同一 domain の feeds.source_name を両方更新する。"""
+  db.add_source("https://example.com/feed", "example.com", "旧名")
+  db.register_feed("a", "https://example.com/a", "example.com", "旧名")
+  db.register_feed("b", "https://example.com/b", "example.com", "旧名")
+  db.register_feed("other", "https://other.com/x", "other.com", "Other")
+
+  assert db.rename_source("https://example.com/feed", "新名") is True
+
+  # sources.name が更新される
+  name = db.conn.execute(
+    "SELECT name FROM sources WHERE url = ?", ("https://example.com/feed",)
+  ).fetchone()[0]
+  assert name == "新名"
+
+  # 同一 domain の feeds.source_name も更新される
+  updated = db.conn.execute(
+    "SELECT source_name FROM feeds WHERE domain = ?", ("example.com",)
+  ).fetchall()
+  assert {r[0] for r in updated} == {"新名"}
+
+  # 別 domain の feeds は巻き添えにしない
+  other = db.conn.execute(
+    "SELECT source_name FROM feeds WHERE domain = ?", ("other.com",)
+  ).fetchone()[0]
+  assert other == "Other"
+
+
+def test_rename_source_missing_returns_false(db):
+  assert db.rename_source("https://notexist.com/feed", "新名") is False
+
+
+def test_rename_source_updates_all_feeds_of_same_domain(db):
+  """feeds は domain でひも付くため、同一 domain の別 source の記事も巻き添えで更新される（既知の性質）。"""
+  db.add_source("https://example.com/feed1", "example.com", "ソース1")
+  db.add_source("https://example.com/feed2", "example.com", "ソース2")
+  db.register_feed("a", "https://example.com/a", "example.com", "ソース1")
+  db.register_feed("b", "https://example.com/b", "example.com", "ソース2")
+
+  assert db.rename_source("https://example.com/feed1", "新名") is True
+
+  # 同一 domain の feeds は source を問わず全て新名になる
+  names = db.conn.execute(
+    "SELECT source_name FROM feeds WHERE domain = ?", ("example.com",)
+  ).fetchall()
+  assert {r[0] for r in names} == {"新名"}
+  # sources 側は rename した source のみ更新される
+  n2 = db.conn.execute(
+    "SELECT name FROM sources WHERE url = ?", ("https://example.com/feed2",)
+  ).fetchone()[0]
+  assert n2 == "ソース2"


### PR DESCRIPTION
## 概要
RSS の title タグが適当だとその名前で登録されてしまい後から直せない、という課題への対応。登録済みフィードの表示名（`sources.name`）を後から変更できるようにしました。Closes #40

## 変更点
### バックエンド
- `StartsDB.rename_source(url, name)` を追加（`db/db.py`）
  - `sources.name` を更新し、同一 domain の `feeds.source_name` も一括更新（既存記事の表示名にも反映）
  - domain は対象 source から引く（`delete_source` と同じ引き方）
  - 対象 source が無ければ False を返す。commit は末尾で1回、既存メソッドに合わせた
- `PATCH /api/sources` を追加（`api.py`、ボディ `{url, name}`）
  - `name` を strip、空なら 400（"名前を入力してください"）
  - 対象なしなら 404（"見つかりません"）
  - 成功時は `{url, name}` を返す
  - `SourceRequest` とは別に `SourceRenameRequest` を用意

### フロント（static/）
- フィード管理タブの各 source-item に「名前変更」ボタンを追加
- 押下で `prompt()`（既定値に現在の名前）→ `PATCH /api/sources` → `loadSources()`/`loadEntries()` 再読込
- name は onclick に埋め込まず url のみ渡し、name は `sourcesCache` から引くことでクォート混入による破壊を回避

### テスト / ドキュメント
- `rename_source` の DB テスト（正常系・別 domain 非巻き添え・対象なし False・同一 domain 複数 source の巻き添え更新）
- `PATCH /api/sources` の API テスト（正常系・空名 400・対象なし 404・feeds.source_name 更新）
- CLAUDE.md に「rename も domain 単位で feeds を一括更新する」旨を追記
- `pytest` 全 31 件緑

## 既知の性質
`feeds` は domain でひも付くため、同一ドメインに複数 source を登録している場合、片方を rename すると両方の記事の表示名が書き換わる（`delete_source` のカスケードと同じ設計）。設計方針で合意済み。

## 手動確認の観点（static/ は pytest 対象外）
- フィード管理タブで「名前変更」→ prompt に現在名が既定表示され、新名を入れると一覧の表示名と新着一覧のグループ見出しが更新される
- prompt をキャンセル / 空文字（空白のみ含む）で送信すると何も起きない
- 存在しない URL や空名でサーバがエラーを返した場合、alert にエラー内容が表示される
- 名前変更ボタンと削除ボタンが右側にグループ表示され、レイアウトが崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)